### PR TITLE
Add support for multiple subnets and on-demand fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,14 @@ inputs:
     required: false
   subnet-id:
     description: >-
-      VPC Subnet Id. The subnet should belong to the same VPC as the specified security group.
+      VPC Subnet Id(s). The subnet(s) should belong to the same VPC as the specified security group.
+      Multiple Subnet IDs can be specified as a JSON array for capacity fallback
       This input is required if you use the 'start' mode.
     required: false
   security-group-id:
     description: >-
       EC2 Security Group Id. 
-      The security group should belong to the same VPC as the specified subnet.
+      The security group should belong to the same VPC as the specified subnet(s).
       The runner doesn't require any inbound traffic. However, outbound traffic should be allowed.
       This input is required if you use the 'start' mode.
     required: false


### PR DESCRIPTION
Multiple subnets allows falling back to a different Availability Zone when there is insufficient capacity in an AZ, subnet-id input can be pecified as JSON Array string ie: '["subnet-1","subnet-2"]' Subnet will be chosen at random.

After trying (and failing) all subnets with a spot request, we will now retry all subnets again with a regular on-demand request. This means if there is no spot capacity, we'll create an on-demand instance instead.